### PR TITLE
fix distribution when simulating

### DIFF
--- a/scripts/02b_definedelays.R
+++ b/scripts/02b_definedelays.R
@@ -20,11 +20,7 @@ ebola_inc_period <- LogNormal(meanlog=convert_to_logmean(11.4, 8.1),
 
 ebola_reporting_delay <- readRDS(here("data", "ebolareportingdelay.RDS")) # estimated from Fang et al. 2016 linelist
 
-ebola_rep_delay <- LogNormal(meanlog=ebola_reporting_delay$mean_mean,
-                             sdlog=ebola_reporting_delay$sd_mean,
-                             max=48)
-
-combined_delay_ebola <- ebola_inc_period + ebola_rep_delay
+combined_delay_ebola <- ebola_inc_period + ebola_reporting_delay
 
 #### SARS-CoV-2-like ####
 

--- a/scripts/05_simulate_data.R
+++ b/scripts/05_simulate_data.R
@@ -27,7 +27,7 @@ ebola_sim_data <- simulate_infections(
   R=rt_ebola_epinow,
   initial_infections=5,
   generation_time=generation_time_opts(ebola_gen_time),
-  delays=delay_opts(combined_delay_ebola),
+  delays=delay_opts(fix_dist(combined_delay_ebola)),
   obs=obs_opts(family="poisson", scale=0.83)
 )
 


### PR DESCRIPTION
Instead of redefining the reporting delay using the central parameters you can use the `fix_dist()` function directly when simulating