### PR TITLE
filter for 1-week forecasts

### DIFF
--- a/R/funcs_plots.R
+++ b/R/funcs_plots.R
@@ -41,7 +41,10 @@ plotcrps <- function(res_samples,
   
   ## Add the info for each scenario to the plot
   ebola_scores_details <- ebola_scores |>
-    left_join(res_id, by="result_list")
+    left_join(res_id, by="result_list") |>
+    group_by(timepoint) |>
+    filter(date == max(date)) |>
+    ungroup()
   
   ### Heatmap by timepoint ###
   


### PR DESCRIPTION
At the moment we're scoring forecasts for every day up to 1 week (1 day ahead, 2 days ahead, ...). The very short term ones are probably more similar than the later ones so I'd suggest to filter for only 1 week ahead before making the comparison, which should give clearer differences.

We could also considering expanding the forecasts to 2-3 weeks to see if it makes a difference to the results (yet another dimension...).