### PR TITLE
don't convert logs

### DIFF
--- a/R/scenario_loop.R
+++ b/R/scenario_loop.R
@@ -46,8 +46,8 @@ sim_scenarios <- function(case_data,
                           max=gen_max)
 
         # Incubation period
-        inc_period <- LogNormal(meanlog=convert_to_logmean(inc_mean*scen_values[j], inc_sd),
-                                sdlog=convert_to_logsd(inc_mean*scen_values[j], inc_sd),
+        inc_period <- LogNormal(mean=inc_mean*scen_values[j]),
+                                sd=inc_mean*scen_values[j]),
                                 max=inc_max)
         
         reporting_delay <- LogNormal(meanlog=rep_meanlog,

--- a/scripts/02b_definedelays.R
+++ b/scripts/02b_definedelays.R
@@ -12,8 +12,8 @@ ebola_gen_time <- Gamma(mean=16.2,
 
 ## Incubation period
 
-ebola_inc_period <- LogNormal(meanlog=convert_to_logmean(11.4, 8.1),
-                              sdlog=convert_to_logsd(11.4, 8.1),
+ebola_inc_period <- LogNormal(mean=11.4,
+                              sd=8.1,
                               max=45) # from Aylward et al. 2014 
 
 ## Reporting delay


### PR DESCRIPTION
with the latest version of EpiNow2 we can specify the mean and sd of a LogNormal directly, without having to use `convert_to_logmean()`