### PR TITLE
use lapply instead of for loops

### DIFF
--- a/scripts/06a_scenario_run_ebola.R
+++ b/scripts/06a_scenario_run_ebola.R
@@ -32,18 +32,11 @@ saveRDS(res_ebola[[3]], here("results", paste0("res_ebola_warnings", Sys.Date(),
 
 ## Saving samples only ##
 
-ebola_samples <- data.frame()
-for(i in 1:length(res_ebola)){
-  samples_scen <- res_ebola[[1]]res_ebola[[i]][res_ebola[[i]]$variable=="reported_cases"] |>
-    mutate(model="EpiNow2")
-# Add ID
-samples_scen$result_list <- i
-
-# Bind to dataframe
-ebola_samples <- rbind(ebola_samples, samples_scen)
-}
-
-ebola_samples <- ebola_samples |>
+ebola_samples <- lapply(1:length(res_ebola[[1]]), function(i) {
+  res_ebola[[1]][[i]][variable=="reported_cases"]
+}) |>
+  bind_rows(.id = "result_list") |>
+  mutate(model = "EpiNow2", result_list = as.integer(result_list)) |>
   rename(prediction=value)
 
 saveRDS(ebola_samples, here("results", paste0("res_ebola_samples", Sys.Date(), ".rds")))

--- a/scripts/06b_scenario_run_covid.R
+++ b/scripts/06b_scenario_run_covid.R
@@ -34,18 +34,11 @@ saveRDS(res_covid[[3]], here("results", paste0("res_covid_warnings", Sys.Date(),
 
 ## Saving samples only ##
 
-covid_samples <- data.frame()
-for(i in 1:length(res_covid)){
-  samples_scen <- res_covid[[1]]res_covid[[i]][res_covid[[i]]$variable=="reported_cases"] |>
-    mutate(model="EpiNow2")
-  
-  # Add ID
-  samples_scen$result_list <- i
-  
-  # Bind to dataframe
-  covid_samples <- rbind(covid_samples, samples_scen)}
-
-covid_samples <- covid_samples |>
+covid_samples <- lapply(1:length(res_ebola[[1]]), function(i) {
+  res_covid[[1]][[i]][$variable=="reported_cases"]
+}) |>
+  bind_rows(.id = "result_list") |>
+  mutate(model = "EpiNow2", result_list = as.integer(result_list)) |>
   rename(prediction=value)
 
 saveRDS(covid_samples, here("results", paste0("res_covid_samples", Sys.Date(), ".rds")))

--- a/scripts/06c_scenario_run_cholera.R
+++ b/scripts/06c_scenario_run_cholera.R
@@ -31,19 +31,19 @@ saveRDS(res_cholera[[3]], here("results", paste0("res_cholera_warnings", Sys.Dat
 
 ## Saving samples only ##
 
-cholera_samples <- data.frame()
-for(i in 1:length(res_cholera)){
-  samples_scen <- res_cholera[[1]]res_cholera[[i]][res_cholera[[i]]$variable=="reported_cases"] |>
+cholera_samples <- lapply(seq_along(res_cholera[[1]]), function(i) {
+  samples_scen <- res_cholera[[1]][[i]][variable=="reported_cases"] |>
     mutate(model="EpiNow2")
 
-# Add ID
-samples_scen$result_list <- i
+  # Add ID
+  samples_scen$result_list <- i
 
-# Bind to dataframe
-cholera_samples <- rbind(cholera_samples, samples_scen)}
+  # Bind to dataframe
+  return(samples_scen)
 
-cholera_samples <- cholera_samples |>
-  rename(prediction=value)
+})
 
 saveRDS(cholera_samples, here("results", paste0("res_cholera_samples", Sys.Date(), ".rds")))
+cholera_samples <- bind_rows(cholera_samples) |>
+  rename(prediction=value)
 


### PR DESCRIPTION
Putting together data.frames by for loop and rbind tends to be slow because every `rbind()` call needs to copy the ever increasing data frame into memory and then concatenate. It's usually quicker to put a list of data frames together first and then concatenate them all via e.g. `dplyr::bind_rows()`. Here's a suggestion for how to do this with the forecast samples.